### PR TITLE
Increase width of instructions button from 10px to 20px

### DIFF
--- a/src/components/InstructionsBar.vue
+++ b/src/components/InstructionsBar.vue
@@ -65,7 +65,7 @@ function onOptionSelect(instructionProps: { index: number, option: any }) {
 <style scoped lang="scss">
 .instructions-button {
 	position: fixed;
-	width: 10px;
+	width: 20px;
 	height: 200px;
 	color: #020617;
 	background: #2a54ff;


### PR DESCRIPTION
This should fix issue #49 . It's not the prettiest solution, but one that works and since i don't know vue i don't feel like i could properly rework the ui to be set in a flexbox with the same behaviour as right now, which to my knowledge is the only thing that can actually dodge the scrollbars.